### PR TITLE
feat: cors allowedOrigins에 cloudfront uri 추가

### DIFF
--- a/src/main/java/com/creddit/credditchatserver/config/CorsConfig.java
+++ b/src/main/java/com/creddit/credditchatserver/config/CorsConfig.java
@@ -9,6 +9,6 @@ public class CorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedOrigins("http://localhost:3000");
+        registry.addMapping("/**").allowedOrigins("http://localhost:3000", "https://ddcoh0c5fwvb1.cloudfront.net");
     }
 }


### PR DESCRIPTION
## What does this PR do?
- client deploy uri를 cors allowed origin 에 추가
-
